### PR TITLE
Add better KS Pro support, add flag leds to RPM led sequence (3/N/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ settings.local.json
 
 usb-capture/
 .venv/
+
+__pycache__

--- a/Devices/MozaDeviceConstants.cs
+++ b/Devices/MozaDeviceConstants.cs
@@ -20,6 +20,10 @@ namespace MozaPlugin.Devices
         /// <summary>Marker prefix returned by GetWheelModelPrefix for old-protocol devices.</summary>
         public const string OldProtocolMarker = "__old__";
 
+        /// <summary>
+        /// Fallback RPM LED count used pre-detection (before the wheel model name
+        /// is known). Known-model code paths should prefer <see cref="WheelModelInfo.RpmLedCount"/>.
+        /// </summary>
         public const int RpmLedCount = 10;
         public const int ButtonLedCount = 14;
         public const int FlagLedCount = 6;
@@ -33,7 +37,7 @@ namespace MozaPlugin.Devices
             { "GS V2P",  "68b2eb89-043e-4e29-be9c-4045c9636124" },
             { "CS V2.1", "cd485bdb-934d-4d06-8224-d24fb1f82bd7" },
             { "CSP",     "503269ba-fc50-44d4-9844-8800da5f9f10" },
-            { "KSP",     "14c84064-a968-43b9-ab92-a02f512632ce" },
+            { "W18",     "14c84064-a968-43b9-ab92-a02f512632ce" },  // KS Pro (firmware reports "W18")
             { "FSR2",    "c4f0cf35-e68c-4756-a04a-b2f8b5d6dbf3" },
         };
 

--- a/Devices/MozaLedDeviceManager.cs
+++ b/Devices/MozaLedDeviceManager.cs
@@ -19,11 +19,14 @@ namespace MozaPlugin.Devices
     {
         private Color[]? _lastLeds;
         private Color[]? _lastButtons;
+        private readonly Color[] _lastFlagColors = new Color[MozaDeviceConstants.FlagLedCount];
+        private bool _lastFlagColorsPrimed;
         private LedDeviceState _lastState = new LedDeviceState(
             Array.Empty<Color>(), Array.Empty<Color>(), Array.Empty<Color>(),
             Array.Empty<Color>(), Array.Empty<Color>(), 1.0, 1.0, 1.0, 1.0);
         private double _lastBrightness = -1;
         private double _lastButtonsBrightness = -1;
+        private double _lastFlagsBrightness = -1;
 
         // Per-component bitmask tracking (avoid redundant bitmask sends)
         private int _lastRpmBitmask = -1;
@@ -76,10 +79,12 @@ namespace MozaPlugin.Devices
                 // Reset cached state so everything re-initializes on reconnect
                 _lastLeds = null;
                 _lastButtons = null;
+                _lastFlagColorsPrimed = false;
                 _lastRpmBitmask = -1;
                 _lastButtonBitmask = -1;
                 _lastBrightness = -1;
                 _lastButtonsBrightness = -1;
+                _lastFlagsBrightness = -1;
                 _ledsAwake = false;
                 OnDisconnect?.Invoke(this, EventArgs.Empty);
             }
@@ -184,27 +189,46 @@ namespace MozaPlugin.Devices
                 bool alwaysResendBitmask = plugin.Settings.AlwaysResendBitmask;
                 bool anySent = false;
 
+                // Wheels with flag LEDs receive a single (rpmN + 6)-LED telemetry
+                // sequence from SimHub laid out as [flag 1..3][rpm 1..N][flag 4..6].
+                // Pre-detection (modelInfo null) we fall back to pure RPM handling.
+                var modelInfo = plugin.WheelModelInfo;
+                bool hasFlagLeds = isNewWheel && modelInfo?.HasFlagLeds == true;
+                int rpmN = modelInfo?.RpmLedCount ?? MozaDeviceConstants.RpmLedCount;
+                int flagLeft = hasFlagLeds ? 3 : 0;
+
+                Color[] rpmColors;
+                if (hasFlagLeds && ledColors.Length >= flagLeft + rpmN)
+                {
+                    rpmColors = new Color[rpmN];
+                    Array.Copy(ledColors, flagLeft, rpmColors, 0, rpmN);
+                }
+                else
+                {
+                    rpmColors = ledColors;
+                }
+
                 // --- RPM LEDs ---
-                bool rpmChanged = _lastLeds == null || !ledColors.SequenceEqual(_lastLeds);
+                bool rpmChanged = _lastLeds == null || !rpmColors.SequenceEqual(_lastLeds);
                 bool shouldSendRpm = rpmChanged || (!limitUpdates && forceRefresh);
 
                 if (shouldSendRpm)
                 {
-                    _lastLeds = (Color[])ledColors.Clone();
+                    _lastLeds = (Color[])rpmColors.Clone();
 
-                    int count = Math.Min(ledColors.Length, MozaDeviceConstants.RpmLedCount);
+                    int count = Math.Min(rpmColors.Length, rpmN);
 
                     // Build bitmask: bit i set if LED i has any color
                     int bitmask = 0;
                     for (int i = 0; i < count; i++)
                     {
-                        if (ledColors[i].R > 0 || ledColors[i].G > 0 || ledColors[i].B > 0)
+                        if (rpmColors[i].R > 0 || rpmColors[i].G > 0 || rpmColors[i].B > 0)
                             bitmask |= (1 << i);
                     }
 
                     if (isNewWheel)
                     {
-                        SendColorChunks(plugin, ledColors, count, "wheel-telemetry-rpm-colors");
+                        SendColorChunks(plugin, rpmColors, count, "wheel-telemetry-rpm-colors");
 
                         if (alwaysResendBitmask || bitmask != _lastRpmBitmask)
                         {
@@ -226,12 +250,34 @@ namespace MozaPlugin.Devices
                     }
                 }
 
+                // --- Flag LEDs ---
+                // Wheels with 3/N/3 flag layout: SimHub indices 0..2 drive flag 1..3,
+                // indices rpmN+3..rpmN+5 drive flag 4..6. Per-LED static color writes
+                // with change detection keep wire traffic low.
+                if (hasFlagLeds && ledColors.Length >= flagLeft + rpmN + 3)
+                {
+                    for (int i = 0; i < MozaDeviceConstants.FlagLedCount; i++)
+                    {
+                        int srcIdx = i < 3 ? i : rpmN + i;  // 0,1,2, rpmN+3, rpmN+4, rpmN+5
+                        var c = ledColors[srcIdx];
+                        bool changed = !_lastFlagColorsPrimed || _lastFlagColors[i] != c;
+                        if (changed || (!limitUpdates && forceRefresh))
+                        {
+                            _lastFlagColors[i] = c;
+                            plugin.DeviceManager.WriteArray(
+                                $"wheel-flag-color{i + 1}",
+                                new byte[] { c.R, c.G, c.B });
+                            anySent = true;
+                        }
+                    }
+                    _lastFlagColorsPrimed = true;
+                }
+
                 // --- Button LEDs (new-protocol wheels only) ---
                 // Gate on WheelModelInfo being known: sending with the fallback mapping
                 // before the model-name response arrives would push wrong-index state that
                 // the cache then treats as current, leaving the wheel misaligned until a
                 // power cycle or forced color change.
-                var modelInfo = plugin.WheelModelInfo;
                 if (isNewWheel && buttonColors.Length > 0 && modelInfo != null)
                 {
                     bool buttonsChanged = _lastButtons == null || !buttonColors.SequenceEqual(_lastButtons);
@@ -275,6 +321,15 @@ namespace MozaPlugin.Devices
                     anySent = true;
                 }
 
+                // Flag brightness is slaved to RPM brightness on wheels with flag LEDs —
+                // the 3/N/3 layout is a single logical strip, so one master knob controls all.
+                if (hasFlagLeds && rpmBrightness != _lastFlagsBrightness)
+                {
+                    _lastFlagsBrightness = rpmBrightness;
+                    plugin.DeviceManager.WriteSetting("wheel-flags-brightness", (int)(rpmBrightness * 100));
+                    anySent = true;
+                }
+
                 if (isNewWheel && buttonsBrightness != _lastButtonsBrightness)
                 {
                     _lastButtonsBrightness = buttonsBrightness;
@@ -310,7 +365,9 @@ namespace MozaPlugin.Devices
         {
             if (_lastLeds == null) return;
 
-            int count = Math.Min(_lastLeds.Length, MozaDeviceConstants.RpmLedCount);
+            var modelInfo = plugin.WheelModelInfo;
+            int rpmN = modelInfo?.RpmLedCount ?? MozaDeviceConstants.RpmLedCount;
+            int count = Math.Min(_lastLeds.Length, rpmN);
 
             if (isNewWheel)
             {
@@ -318,6 +375,17 @@ namespace MozaPlugin.Devices
                 if (_lastRpmBitmask >= 0)
                     plugin.DeviceManager.WriteArray("wheel-send-rpm-telemetry",
                         new byte[] { (byte)(_lastRpmBitmask & 0xFF), (byte)((_lastRpmBitmask >> 8) & 0xFF) });
+
+                if (modelInfo?.HasFlagLeds == true && _lastFlagColorsPrimed)
+                {
+                    for (int i = 0; i < MozaDeviceConstants.FlagLedCount; i++)
+                    {
+                        var c = _lastFlagColors[i];
+                        plugin.DeviceManager.WriteArray(
+                            $"wheel-flag-color{i + 1}",
+                            new byte[] { c.R, c.G, c.B });
+                    }
+                }
             }
             else if (isOldWheel)
             {

--- a/Devices/MozaWheelSettingsControl.xaml
+++ b/Devices/MozaWheelSettingsControl.xaml
@@ -108,11 +108,6 @@
                         <TextBlock Style="{StaticResource LedIndex}" Text="5"/><TextBlock Style="{StaticResource LedIndex}" Text="6"/>
                     </StackPanel>
                     <StackPanel x:Name="WheelFlagColorPanel" Orientation="Horizontal" Margin="0,0,0,10"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,4">
-                        <TextBlock Text="Flags Brightness" Style="{StaticResource SliderLabel}"/>
-                        <Slider x:Name="WheelFlagsBrightnessSlider" Style="{StaticResource SettingSlider}" Minimum="0" Maximum="100" TickFrequency="1" ValueChanged="WheelFlagsBrightnessSlider_ValueChanged"/>
-                        <TextBlock x:Name="WheelFlagsBrightnessValue" Style="{StaticResource SliderValue}" Text="100"/>
-                    </StackPanel>
                 </StackPanel>
 
                 <TextBlock Text="Button LED Colors" Style="{StaticResource SectionHeader}"/>

--- a/Devices/MozaWheelSettingsControl.xaml.cs
+++ b/Devices/MozaWheelSettingsControl.xaml.cs
@@ -198,9 +198,6 @@ namespace MozaPlugin.Devices
                                 ? Visibility.Visible : Visibility.Collapsed;
                     }
 
-                    WheelFlagsBrightnessSlider.Value = Clamp(_data.WheelFlagsBrightness, 0, 100);
-                    WheelFlagsBrightnessValue.Text = $"{_data.WheelFlagsBrightness}";
-
                     UpdateSwatches(_wheelFlagColorSwatches, _data.WheelFlagColors, 6);
                     UpdateSwatches(_wheelButtonColorSwatches, _data.WheelButtonColors, 14);
                 }
@@ -271,17 +268,6 @@ namespace MozaPlugin.Devices
             _data!.WheelButtonsIdleEffect = val;
             _settings!.WheelButtonsIdleEffect = val;
             _device!.WriteSetting("wheel-buttons-idle-effect", val);
-            _plugin.SaveSettings();
-        }
-
-        private void WheelFlagsBrightnessSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            if (_suppressEvents || _plugin == null) return;
-            int val = (int)Math.Round(e.NewValue);
-            WheelFlagsBrightnessValue.Text = $"{val}";
-            _data!.WheelFlagsBrightness = val;
-            _settings!.WheelFlagsBrightness = val;
-            _device!.WriteSetting("wheel-flags-brightness", val);
             _plugin.SaveSettings();
         }
 

--- a/Devices/WheelModelInfo.cs
+++ b/Devices/WheelModelInfo.cs
@@ -9,10 +9,16 @@ namespace MozaPlugin.Devices
     /// </summary>
     internal class WheelModelInfo
     {
+        /// <summary>Number of physical RPM LEDs on this wheel (center section of the LED strip).</summary>
+        public int RpmLedCount { get; }
+
         /// <summary>Number of physical button LEDs on this wheel.</summary>
         public int ButtonLedCount { get; }
 
-        /// <summary>Whether this wheel has physical flag LEDs.</summary>
+        /// <summary>
+        /// Whether this wheel has 6 physical flag LEDs arranged as 3 on the left and 3
+        /// on the right of the RPM strip (total physical telemetry LEDs = RpmLedCount + 6).
+        /// </summary>
         public bool HasFlagLeds { get; }
 
         /// <summary>
@@ -21,8 +27,8 @@ namespace MozaPlugin.Devices
         /// </summary>
         public int[]? ButtonLedMap { get; }
 
-        /// <summary>Default for unknown models — 14 buttons, no flags, contiguous.</summary>
-        public static readonly WheelModelInfo Default = new(14, false, null);
+        /// <summary>Default for unknown models — 10 RPM, 14 buttons, no flags, contiguous.</summary>
+        public static readonly WheelModelInfo Default = new(10, 14, false, null);
 
         /// <summary>
         /// Known wheel models, ordered longest prefix first for correct disambiguation.
@@ -32,18 +38,19 @@ namespace MozaPlugin.Devices
         /// </summary>
         internal static readonly (string Prefix, string FriendlyName, WheelModelInfo Info)[] KnownModels =
         {
-            ("GS V2P",  "GS V2 Pro",  new WheelModelInfo(10, false, null)),
-            ("CS V2.1", "CS V2",      new WheelModelInfo(6,  false, new[] { 0, 1, 3, 6, 8, 9 })),
-            ("CSP",     "CS Pro",     new WheelModelInfo(14, true,  null)),
-            ("KSP",     "KS Pro",     new WheelModelInfo(14, true,  null)),
-            ("KS",      "KS",         new WheelModelInfo(10, false, null)),
-            ("FSR2",    "FSR V2",     new WheelModelInfo(14, true,  null)),
-            ("VGS",     "Vision GS",  new WheelModelInfo(8,  false, null)),
-            ("TSW",     "TSW",        new WheelModelInfo(14, false, null)),
+            ("GS V2P",  "GS V2 Pro",  new WheelModelInfo(10, 10, false, null)),
+            ("CS V2.1", "CS V2",      new WheelModelInfo(10, 6,  false, new[] { 0, 1, 3, 6, 8, 9 })),
+            ("CSP",     "CS Pro",     new WheelModelInfo(10, 14, true,  null)),
+            ("W18",     "KS Pro",     new WheelModelInfo(12, 14, true,  null)),  // firmware reports "W18" for KS Pro
+            ("KS",      "KS",         new WheelModelInfo(10, 10, false, null)),
+            ("FSR2",    "FSR V2",     new WheelModelInfo(10, 14, true,  null)),
+            ("VGS",     "Vision GS",  new WheelModelInfo(10, 8,  false, null)),
+            ("TSW",     "TSW",        new WheelModelInfo(10, 14, false, null)),
         };
 
-        public WheelModelInfo(int buttonLedCount, bool hasFlagLeds, int[]? buttonLedMap)
+        public WheelModelInfo(int rpmLedCount, int buttonLedCount, bool hasFlagLeds, int[]? buttonLedMap)
         {
+            RpmLedCount = rpmLedCount;
             ButtonLedCount = buttonLedCount;
             HasFlagLeds = hasFlagLeds;
             ButtonLedMap = buttonLedMap;

--- a/MozaPlugin.cs
+++ b/MozaPlugin.cs
@@ -733,7 +733,7 @@ namespace MozaPlugin
                         WheelModelInfo = Devices.WheelModelInfo.FromModelName(_data.WheelModelName);
                         SimHub.Logging.Current.Info(
                             $"[Moza] Wheel model: {_data.WheelModelName} " +
-                            $"(buttons={WheelModelInfo.ButtonLedCount}, flags={WheelModelInfo.HasFlagLeds})");
+                            $"(rpm={WheelModelInfo.RpmLedCount}, buttons={WheelModelInfo.ButtonLedCount}, flags={WheelModelInfo.HasFlagLeds})");
                         DeployDeviceDefinitionForModel(_data.WheelModelName);
                     }
                     else
@@ -1455,10 +1455,10 @@ namespace MozaPlugin
             var modelInfo = WheelModelInfo.FromModelName(modelName);
             var deviceName = "MOZA " + friendlyName;
 
-            DeployGeneratedWheelDefinition(deviceName, guid, friendlyName, modelInfo.ButtonLedCount);
+            DeployGeneratedWheelDefinition(deviceName, guid, friendlyName, modelInfo.RpmLedCount, modelInfo.HasFlagLeds, modelInfo.ButtonLedCount);
         }
 
-        private void DeployGeneratedWheelDefinition(string deviceName, string guid, string productName, int buttonCount)
+        private void DeployGeneratedWheelDefinition(string deviceName, string guid, string productName, int rpmCount, bool hasFlagLeds, int buttonCount)
         {
             try
             {
@@ -1467,19 +1467,44 @@ namespace MozaPlugin
                 var deviceDir = Path.Combine(userDefsDir, deviceName);
                 var deviceJsonPath = Path.Combine(deviceDir, "device.json");
 
-                if (File.Exists(deviceJsonPath))
-                    return;
+                int expectedTelemetryCount = rpmCount + (hasFlagLeds ? 6 : 0);
+                bool fileExists = File.Exists(deviceJsonPath);
+                bool stale = false;
+
+                if (fileExists)
+                {
+                    // Compare existing LogicalTelemetryLeds.LedCount + LogicalButtonsSection.Items
+                    // against expected. Mismatch = layout changed in a plugin update; rewrite.
+                    try
+                    {
+                        var existing = JObject.Parse(File.ReadAllText(deviceJsonPath));
+                        int existingLed = existing.SelectToken("LedsFeature.LogicalTelemetryLeds.LedCount")?.Value<int>() ?? -1;
+                        int existingButtons = (existing.SelectToken("LedsFeature.LogicalButtonsSection.Items") as JArray)?.Count ?? -1;
+                        stale = existingLed != expectedTelemetryCount || existingButtons != buttonCount;
+                    }
+                    catch (Exception parseEx)
+                    {
+                        SimHub.Logging.Current.Warn(
+                            $"[Moza] Could not parse existing device.json for '{deviceName}', rewriting: {parseEx.Message}");
+                        stale = true;
+                    }
+
+                    if (!stale)
+                        return;
+                }
 
                 Directory.CreateDirectory(deviceDir);
 
                 var pid = _connection.DiscoveredPid ?? "0x0004";
-                var json = GenerateWheelDeviceJson(guid, productName, buttonCount, pid);
+                var json = GenerateWheelDeviceJson(guid, productName, rpmCount, hasFlagLeds, buttonCount, pid);
                 File.WriteAllText(deviceJsonPath, json);
 
                 DeviceDefinitionDeployed = true;
+                string action = stale ? "Refreshed" : "Deployed";
                 SimHub.Logging.Current.Info(
-                    $"[Moza] Deployed device definition: {deviceName} " +
-                    $"(guid={guid}, buttons={buttonCount}, pid={pid}, restart SimHub to add it)");
+                    $"[Moza] {action} device definition: {deviceName} " +
+                    $"(guid={guid}, telemetryLeds={expectedTelemetryCount}, rpm={rpmCount}, flags={hasFlagLeds}, " +
+                    $"buttons={buttonCount}, pid={pid}, restart SimHub to pick up changes)");
             }
             catch (Exception ex)
             {
@@ -1487,19 +1512,22 @@ namespace MozaPlugin
             }
         }
 
-        private static string GenerateWheelDeviceJson(string guid, string productName, int buttonCount, string pid)
+        private static string GenerateWheelDeviceJson(string guid, string productName, int rpmCount, bool hasFlagLeds, int buttonCount, string pid)
         {
             var physItems = new JArray();
 
-            // RPM LEDs: 10 slots (first has the mapping, rest are empty continuations)
+            // Telemetry LEDs: single contiguous sequence. When the wheel has flag LEDs
+            // they are 3-on-each-side of the RPM strip, so SimHub sees (rpmCount + 6)
+            // LEDs as one logical run: [flag 1..3][rpm 1..N][flag 4..6].
+            int telemetryCount = rpmCount + (hasFlagLeds ? 6 : 0);
             physItems.Add(new JObject
             {
                 ["SourceRole"] = 1,
                 ["SourceIndex"] = 0,
-                ["RepeatCount"] = MozaDeviceConstants.RpmLedCount,
+                ["RepeatCount"] = telemetryCount,
                 ["RepeatMode"] = 1
             });
-            for (int i = 1; i < MozaDeviceConstants.RpmLedCount; i++)
+            for (int i = 1; i < telemetryCount; i++)
                 physItems.Add(new JObject());
 
             // Button LEDs: buttonCount slots
@@ -1540,8 +1568,10 @@ namespace MozaPlugin
                     ["PhysicalLedsMappings"] = new JObject { ["Items"] = physItems },
                     ["LogicalTelemetryLeds"] = new JObject
                     {
-                        ["LedCount"] = MozaDeviceConstants.RpmLedCount,
-                        ["Segments"] = new JArray(),
+                        ["LedCount"] = telemetryCount,
+                        ["Segments"] = hasFlagLeds
+                            ? new JArray(new JObject { ["Size"] = 3 })
+                            : new JArray(),
                         ["IsEnabled"] = true
                     },
                     ["LogicalButtonsSection"] = new JObject


### PR DESCRIPTION
Additional support for KS Pro, hopefully fixes #13, #19.

* May need to delete wheel device, restart simhub, and re-add for layout changes to have a full effect
* Flag LEDs are mapped in order on either side of RPM index (3/10/3 or 3/12/3 depending on wheel)
  * May need to change start index for effects as needed