### PR TITLE
Add German (de) translation

### DIFF
--- a/MozaPlugin.csproj
+++ b/MozaPlugin.csproj
@@ -75,6 +75,10 @@
     <EmbeddedResource Update="Resources\Strings.resx">
       <ManifestResourceName>MozaPlugin.Resources.Strings</ManifestResourceName>
     </EmbeddedResource>
+    <EmbeddedResource Update="Resources\Strings.de.resx">
+      <WithCulture>false</WithCulture>
+      <ManifestResourceName>MozaPlugin.Resources.Strings.de</ManifestResourceName>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resources\Strings.es.resx">
       <WithCulture>false</WithCulture>
       <ManifestResourceName>MozaPlugin.Resources.Strings.es</ManifestResourceName>

--- a/Resources/LanguageResolver.cs
+++ b/Resources/LanguageResolver.cs
@@ -40,7 +40,7 @@ namespace MozaPlugin.Resources
         // language means: drop Strings.<lang>.resx in Resources/, append the
         // culture code here, add an EmbeddedResource entry in MozaPlugin.csproj,
         // and add a DisplayNames entry below.
-        public static readonly IReadOnlyList<string> SupportedCultures = new[] { "en", "es", "fr", "ru", "vi" };
+        public static readonly IReadOnlyList<string> SupportedCultures = new[] { "en", "de", "es", "fr", "ru", "vi" };
 
         // Names shown in the in-plugin language ComboBox. Each language is
         // named in its own tongue so a user who can't read the current UI can
@@ -49,6 +49,7 @@ namespace MozaPlugin.Resources
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "en", "English" },
+                { "de", "Deutsch" },
                 { "es", "Español" },
                 { "fr", "Français" },
                 { "ru", "Русский" },

--- a/Resources/Strings.Designer.cs
+++ b/Resources/Strings.Designer.cs
@@ -32,6 +32,7 @@ namespace MozaPlugin.Resources
             new Dictionary<string, ResourceManager>(System.StringComparer.OrdinalIgnoreCase)
             {
                 { "",   new ResourceManager("MozaPlugin.Resources.Strings",    typeof(Strings).Assembly) },
+                { "de", new ResourceManager("MozaPlugin.Resources.Strings.de", typeof(Strings).Assembly) },
                 { "es", new ResourceManager("MozaPlugin.Resources.Strings.es", typeof(Strings).Assembly) },
                 { "fr", new ResourceManager("MozaPlugin.Resources.Strings.fr", typeof(Strings).Assembly) },
                 { "ru", new ResourceManager("MozaPlugin.Resources.Strings.ru", typeof(Strings).Assembly) },

--- a/Resources/Strings.de.resx
+++ b/Resources/Strings.de.resx
@@ -117,9 +117,9 @@
   <data name="Label_Throttle" xml:space="preserve"><value>GAS</value></data>
   <data name="Label_Brake" xml:space="preserve"><value>BREMSE</value></data>
   <data name="Label_Clutch" xml:space="preserve"><value>KUPPLUNG</value></data>
-  <data name="Section_ThrottleDirectionRange" xml:space="preserve"><value>GAS · RICHTUNG & BEREICH</value></data>
-  <data name="Section_BrakeDirectionRange" xml:space="preserve"><value>BREMSE · RICHTUNG & BEREICH</value></data>
-  <data name="Section_ClutchDirectionRange" xml:space="preserve"><value>KUPPLUNG · RICHTUNG & BEREICH</value></data>
+  <data name="Section_ThrottleDirectionRange" xml:space="preserve"><value>GAS · RICHTUNG &amp; BEREICH</value></data>
+  <data name="Section_BrakeDirectionRange" xml:space="preserve"><value>BREMSE · RICHTUNG &amp; BEREICH</value></data>
+  <data name="Section_ClutchDirectionRange" xml:space="preserve"><value>KUPPLUNG · RICHTUNG &amp; BEREICH</value></data>
   <data name="Section_ThrottleOutputCurve" xml:space="preserve"><value>GAS-AUSGABEKURVE</value></data>
   <data name="Section_BrakeOutputCurve" xml:space="preserve"><value>BREMSEN-AUSGABEKURVE</value></data>
   <data name="Section_ClutchOutputCurve" xml:space="preserve"><value>KUPPLUNGS-AUSGABEKURVE</value></data>
@@ -208,7 +208,7 @@
   <data name="Option_FirmwareEra2026" xml:space="preserve"><value>Ära 2026 — CSP/KSP</value></data>
   <data name="Hint_FirmwareEra" xml:space="preserve"><value>Auto ermittelt die Firmware-Ära aus dem Handshake des Lenkrads und wählt das passende Protokoll. Nur überschreiben, falls die Telemetrie nicht funktioniert.</value></data>
   <data name="Section_Reset" xml:space="preserve"><value>ZURÜCKSETZEN</value></data>
-  <data name="Button_ClearAllSettings" xml:space="preserve"><value>ALLE EINSTELLUNGEN & PROFILE LÖSCHEN</value></data>
+  <data name="Button_ClearAllSettings" xml:space="preserve"><value>ALLE EINSTELLUNGEN &amp; PROFILE LÖSCHEN</value></data>
   <data name="Hint_ClearAllSettingsWarning" xml:space="preserve"><value>Damit werden alle Plugin-Einstellungen und Profile auf ihre Standardwerte zurückgesetzt.</value></data>
   <data name="Banner_NotWorkingYet" xml:space="preserve"><value>⚠  Funktioniert noch nicht</value></data>
   <data name="Hint_DashboardUploadNotWorking" xml:space="preserve"><value>Der Dashboard-Upload ist in Entwicklung und überträgt aktuell KEINE Dateien an das Lenkrad.</value></data>

--- a/Resources/Strings.de.resx
+++ b/Resources/Strings.de.resx
@@ -1,0 +1,467 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TabHeader_Base" xml:space="preserve"><value>Base</value></data>
+  <data name="TabHeader_Wheel" xml:space="preserve"><value>Lenkrad</value></data>
+  <data name="TabHeader_Handbrake" xml:space="preserve"><value>Handbremse</value></data>
+  <data name="TabHeader_Pedals" xml:space="preserve"><value>Pedale</value></data>
+  <data name="TabHeader_Ab9Shifter" xml:space="preserve"><value>AB9 Schalthebel</value></data>
+  <data name="TabHeader_MBooster" xml:space="preserve"><value>mBooster</value></data>
+  <data name="TabHeader_Hub" xml:space="preserve"><value>Hub</value></data>
+  <data name="TabHeader_Options" xml:space="preserve"><value>Optionen</value></data>
+  <data name="TabHeader_Upload" xml:space="preserve"><value>Hochladen</value></data>
+  <data name="TabHeader_WheelFiles" xml:space="preserve"><value>Lenkrad-Dateien</value></data>
+  <data name="TabHeader_Sdk" xml:space="preserve"><value>SDK</value></data>
+  <data name="TabHeader_About" xml:space="preserve"><value>Über</value></data>
+  <data name="Brand_Unofficial" xml:space="preserve"><value>INOFFIZIELL</value></data>
+  <data name="Brand_Moza" xml:space="preserve"><value>MOZA</value></data>
+  <data name="Brand_SimHubPlugin" xml:space="preserve"><value>SimHub-Plugin</value></data>
+  <data name="Status_Disconnected" xml:space="preserve"><value>Getrennt</value></data>
+  <data name="Button_Refresh" xml:space="preserve"><value>AKTUALISIEREN</value></data>
+  <data name="Label_PerformanceOutput" xml:space="preserve"><value>Leistungsausgabe</value></data>
+  <data name="Option_Reserved" xml:space="preserve"><value>Reserviert</value></data>
+  <data name="Option_Full" xml:space="preserve"><value>Voll</value></data>
+  <data name="Button_CalibrateCenter" xml:space="preserve"><value>MITTE KALIBRIEREN</value></data>
+  <data name="Brand_Mcu" xml:space="preserve"><value>MCU</value></data>
+  <data name="Brand_Mosfet" xml:space="preserve"><value>MOSFET</value></data>
+  <data name="Brand_Motor" xml:space="preserve"><value>MOTOR</value></data>
+  <data name="Section_CoreSettings" xml:space="preserve"><value>GRUNDEINSTELLUNGEN</value></data>
+  <data name="Section_GearshiftVibration" xml:space="preserve"><value>SCHALTVIBRATION</value></data>
+  <data name="SliderLabel_WheelRotationAngle" xml:space="preserve"><value>Lenkradeinschlagwinkel</value></data>
+  <data name="SliderLabel_GameFfbStrength" xml:space="preserve"><value>Spiel-FFB-Stärke</value></data>
+  <data name="SliderLabel_BaseTorqueOutput" xml:space="preserve"><value>Drehmoment der Base</value></data>
+  <data name="SliderLabel_MaximumWheelSpeed" xml:space="preserve"><value>Maximale Lenkraddrehzahl</value></data>
+  <data name="SliderLabel_ShiftIntensity" xml:space="preserve"><value>Schaltintensität</value></data>
+  <data name="SliderLabel_VibrateOnNeutral" xml:space="preserve"><value>Im Leerlauf vibrieren</value></data>
+  <data name="SliderLabel_ShiftDebounce" xml:space="preserve"><value>Schalt-Entprellung</value></data>
+  <data name="Section_WheelbaseEffects" xml:space="preserve"><value>BASE-EFFEKTE</value></data>
+  <data name="Section_GameEffects" xml:space="preserve"><value>SPIEL-EFFEKTE</value></data>
+  <data name="SliderLabel_WheelDamper" xml:space="preserve"><value>Lenkrad-Dämpfung</value></data>
+  <data name="SliderLabel_WheelFriction" xml:space="preserve"><value>Lenkrad-Reibung</value></data>
+  <data name="SliderLabel_NaturalInertia" xml:space="preserve"><value>Natürliche Trägheit</value></data>
+  <data name="SliderLabel_WheelSpring" xml:space="preserve"><value>Lenkrad-Feder</value></data>
+  <data name="SliderLabel_GameDamper" xml:space="preserve"><value>Spiel-Dämpfung</value></data>
+  <data name="SliderLabel_GameFriction" xml:space="preserve"><value>Spiel-Reibung</value></data>
+  <data name="SliderLabel_GameInertia" xml:space="preserve"><value>Spiel-Trägheit</value></data>
+  <data name="SliderLabel_GameSpring" xml:space="preserve"><value>Spiel-Feder</value></data>
+  <data name="Section_Protection" xml:space="preserve"><value>SCHUTZ</value></data>
+  <data name="Section_SoftLimit" xml:space="preserve"><value>SOFT-LIMIT</value></data>
+  <data name="SliderLabel_HandsOffProtection" xml:space="preserve"><value>Hands-Off-Schutz</value></data>
+  <data name="SliderLabel_SteeringWheelInertia" xml:space="preserve"><value>Lenkrad-Trägheit</value></data>
+  <data name="SliderLabel_Stiffness" xml:space="preserve"><value>Steifigkeit</value></data>
+  <data name="SliderLabel_RetainGameFfb" xml:space="preserve"><value>Spiel-FFB beibehalten</value></data>
+  <data name="Section_FfbEqualizer" xml:space="preserve"><value>FFB-EQUALIZER</value></data>
+  <data name="Subtitle_FfbEqualizer" xml:space="preserve"><value>// Verstärkung pro Band · 100 % = neutral · 400 % = max. Boost</value></data>
+  <data name="Section_FfbOutputCurve" xml:space="preserve"><value>FFB-AUSGABEKURVE</value></data>
+  <data name="Subtitle_FfbOutputCurve" xml:space="preserve"><value>// die 5 Knoten ziehen, um den Verlauf zu formen</value></data>
+  <data name="Button_Flat" xml:space="preserve"><value>FLACH</value></data>
+  <data name="Button_Falloff" xml:space="preserve"><value>ABFALL</value></data>
+  <data name="Button_Linear" xml:space="preserve"><value>LINEAR</value></data>
+  <data name="Button_SCurve" xml:space="preserve"><value>S-KURVE</value></data>
+  <data name="Button_Exponential" xml:space="preserve"><value>EXPONENTIELL</value></data>
+  <data name="Button_Parabolic" xml:space="preserve"><value>PARABOLISCH</value></data>
+  <data name="Section_Miscellaneous" xml:space="preserve"><value>SONSTIGES</value></data>
+  <data name="Section_HighSpeedDamping" xml:space="preserve"><value>DÄMPFUNG BEI HOHER GESCHWINDIGKEIT</value></data>
+  <data name="Subtitle_HighSpeedDamping" xml:space="preserve"><value>// keine Ahnung, was diese Einstellungen bewirken</value></data>
+  <data name="SliderLabel_ForceFeedbackReversal" xml:space="preserve"><value>Force-Feedback-Umkehrung</value></data>
+  <data name="SliderLabel_StandbyMode" xml:space="preserve"><value>Standby-Modus</value></data>
+  <data name="SliderLabel_BaseStatusLed" xml:space="preserve"><value>Base-Status-LED</value></data>
+  <data name="SliderLabel_Bluetooth" xml:space="preserve"><value>Bluetooth</value></data>
+  <data name="SliderLabel_DampingLevel" xml:space="preserve"><value>Dämpfungsstufe</value></data>
+  <data name="SliderLabel_TriggerSpeed" xml:space="preserve"><value>Auslösegeschwindigkeit</value></data>
+  <data name="Section_Paddles" xml:space="preserve"><value>Paddles</value></data>
+  <data name="Label_LeftPaddle" xml:space="preserve"><value>Linkes Paddle</value></data>
+  <data name="Label_RightPaddle" xml:space="preserve"><value>Rechtes Paddle</value></data>
+  <data name="Label_Combined" xml:space="preserve"><value>Kombiniert</value></data>
+  <data name="Section_Buttons" xml:space="preserve"><value>Tasten</value></data>
+  <data name="Section_PaddleSettings" xml:space="preserve"><value>PADDLE-EINSTELLUNGEN</value></data>
+  <data name="SliderLabel_PaddlesMode" xml:space="preserve"><value>Paddle-Modus</value></data>
+  <data name="Option_Buttons" xml:space="preserve"><value>Tasten</value></data>
+  <data name="Option_Combined" xml:space="preserve"><value>Kombiniert</value></data>
+  <data name="Option_Split" xml:space="preserve"><value>Geteilt</value></data>
+  <data name="SliderLabel_ClutchSplitPoint" xml:space="preserve"><value>Kupplungs-Trennpunkt</value></data>
+  <data name="Section_InputSettings" xml:space="preserve"><value>Eingabeeinstellungen</value></data>
+  <data name="SliderLabel_RotaryEncoders" xml:space="preserve"><value>Drehgeber</value></data>
+  <data name="Option_Knob" xml:space="preserve"><value>Drehregler</value></data>
+  <data name="SliderLabel_Rotary1" xml:space="preserve"><value>Drehregler 1</value></data>
+  <data name="SliderLabel_Rotary2" xml:space="preserve"><value>Drehregler 2</value></data>
+  <data name="SliderLabel_Rotary3" xml:space="preserve"><value>Drehregler 3</value></data>
+  <data name="SliderLabel_Rotary4" xml:space="preserve"><value>Drehregler 4</value></data>
+  <data name="SliderLabel_Rotary5" xml:space="preserve"><value>Drehregler 5</value></data>
+  <data name="SliderLabel_StickAsDpad" xml:space="preserve"><value>Stick als Steuerkreuz</value></data>
+  <data name="SliderLabel_JoystickAssignment" xml:space="preserve"><value>Joystick-Zuordnung</value></data>
+  <data name="Option_None" xml:space="preserve"><value>Keine</value></data>
+  <data name="Option_Left" xml:space="preserve"><value>Links</value></data>
+  <data name="Option_Right" xml:space="preserve"><value>Rechts</value></data>
+  <data name="Hint_LedButtonSettingsInDeviceTab" xml:space="preserve"><value>LED- und Tasten-Einstellungen findest du im Geräte-Tab des MOZA Wheel unter „Devices“.</value></data>
+  <data name="Section_Position" xml:space="preserve"><value>POSITION</value></data>
+  <data name="Subtitle_LiveHandbrakeInput" xml:space="preserve"><value>// Live-Handbremsen-Eingabe</value></data>
+  <data name="Label_Position" xml:space="preserve"><value>Position</value></data>
+  <data name="Section_Calibration" xml:space="preserve"><value>KALIBRIERUNG</value></data>
+  <data name="Subtitle_PullHandbrakeFully" xml:space="preserve"><value>// Handbremse einmal vollständig durchziehen</value></data>
+  <data name="Button_StartCalibration" xml:space="preserve"><value>KALIBRIERUNG STARTEN</value></data>
+  <data name="Button_Stop" xml:space="preserve"><value>STOPP</value></data>
+  <data name="Section_HandbrakeSettings" xml:space="preserve"><value>HANDBREMSEN-EINSTELLUNGEN</value></data>
+  <data name="SliderLabel_Mode" xml:space="preserve"><value>Modus</value></data>
+  <data name="Option_Axis" xml:space="preserve"><value>Achse</value></data>
+  <data name="Option_Button" xml:space="preserve"><value>Taste</value></data>
+  <data name="SliderLabel_ButtonThreshold" xml:space="preserve"><value>Tasten-Schwellwert</value></data>
+  <data name="SliderLabel_ReverseDirection" xml:space="preserve"><value>Richtung umkehren</value></data>
+  <data name="SliderLabel_RangeStart" xml:space="preserve"><value>Bereichsanfang</value></data>
+  <data name="SliderLabel_RangeEnd" xml:space="preserve"><value>Bereichsende</value></data>
+  <data name="Section_OutputCurve" xml:space="preserve"><value>AUSGABEKURVE</value></data>
+  <data name="Subtitle_MapPhysicalPullToGame" xml:space="preserve"><value>// physisches Ziehen auf Spieleingabe abbilden</value></data>
+  <data name="Label_Throttle" xml:space="preserve"><value>GAS</value></data>
+  <data name="Label_Brake" xml:space="preserve"><value>BREMSE</value></data>
+  <data name="Label_Clutch" xml:space="preserve"><value>KUPPLUNG</value></data>
+  <data name="Section_ThrottleDirectionRange" xml:space="preserve"><value>GAS · RICHTUNG & BEREICH</value></data>
+  <data name="Section_BrakeDirectionRange" xml:space="preserve"><value>BREMSE · RICHTUNG & BEREICH</value></data>
+  <data name="Section_ClutchDirectionRange" xml:space="preserve"><value>KUPPLUNG · RICHTUNG & BEREICH</value></data>
+  <data name="Section_ThrottleOutputCurve" xml:space="preserve"><value>GAS-AUSGABEKURVE</value></data>
+  <data name="Section_BrakeOutputCurve" xml:space="preserve"><value>BREMSEN-AUSGABEKURVE</value></data>
+  <data name="Section_ClutchOutputCurve" xml:space="preserve"><value>KUPPLUNGS-AUSGABEKURVE</value></data>
+  <data name="Subtitle_MapPhysicalPositionToGame" xml:space="preserve"><value>// physische Position auf Spieleingabe abbilden</value></data>
+  <data name="Subtitle_ShapeBrakeResponse" xml:space="preserve"><value>// Bremsverhalten formen</value></data>
+  <data name="Subtitle_ShapeClutchResponse" xml:space="preserve"><value>// Kupplungsverhalten formen</value></data>
+  <data name="Section_ThrottleCalibration" xml:space="preserve"><value>GAS · KALIBRIERUNG</value></data>
+  <data name="Section_BrakeCalibration" xml:space="preserve"><value>BREMSE · KALIBRIERUNG</value></data>
+  <data name="Section_ClutchCalibration" xml:space="preserve"><value>KUPPLUNG · KALIBRIERUNG</value></data>
+  <data name="SliderLabel_SensorRatio" xml:space="preserve"><value>Sensorverhältnis</value></data>
+  <data name="Hint_AngleSensorVsLoadCell" xml:space="preserve"><value>0 % = Winkelsensor · 100 % = Wägezelle</value></data>
+  <data name="Section_Ab9ActiveShifter" xml:space="preserve"><value>AB9 AKTIVER SCHALTHEBEL</value></data>
+  <data name="Status_SearchingForAb9" xml:space="preserve"><value>Suche nach AB9…</value></data>
+  <data name="Section_MechanicalLayout" xml:space="preserve"><value>MECHANISCHES LAYOUT</value></data>
+  <data name="Option_Ab9Layout5R1" xml:space="preserve"><value>5+R Layout 1</value></data>
+  <data name="Option_Ab9Layout6R1" xml:space="preserve"><value>6+R Layout 1</value></data>
+  <data name="Option_Ab9Layout6R2" xml:space="preserve"><value>6+R Layout 2</value></data>
+  <data name="Option_Ab9Layout7R1" xml:space="preserve"><value>7+R Layout 1</value></data>
+  <data name="Option_Ab9Layout7R2" xml:space="preserve"><value>7+R Layout 2</value></data>
+  <data name="Option_Sequential" xml:space="preserve"><value>Sequenziell</value></data>
+  <data name="Section_Feel" xml:space="preserve"><value>GEFÜHL</value></data>
+  <data name="Subtitle_PerAxisMechanicalCharacter" xml:space="preserve"><value>// mechanischer Charakter pro Achse</value></data>
+  <data name="SliderLabel_MechanicalResistance" xml:space="preserve"><value>Mechanischer Widerstand</value></data>
+  <data name="SliderLabel_Spring" xml:space="preserve"><value>Feder</value></data>
+  <data name="SliderLabel_NaturalDamping" xml:space="preserve"><value>Natürliche Dämpfung</value></data>
+  <data name="SliderLabel_NaturalFriction" xml:space="preserve"><value>Natürliche Reibung</value></data>
+  <data name="SliderLabel_MaxOutputTorqueLimit" xml:space="preserve"><value>Max. Ausgangsdrehmoment-Limit</value></data>
+  <data name="Section_EngineVibration" xml:space="preserve"><value>MOTORVIBRATION</value></data>
+  <data name="Subtitle_HostRenderedRumble" xml:space="preserve"><value>// vom Host aus Drehzahl erzeugtes Rumble</value></data>
+  <data name="SliderLabel_Intensity" xml:space="preserve"><value>Intensität</value></data>
+  <data name="SliderLabel_Frequency" xml:space="preserve"><value>Frequenz</value></data>
+  <data name="Section_GearShift" xml:space="preserve"><value>SCHALTVORGANG</value></data>
+  <data name="SliderLabel_VibrationIntensity" xml:space="preserve"><value>Vibrationsintensität</value></data>
+  <data name="Section_MBoosterPedals" xml:space="preserve"><value>MBOOSTER-PEDALE</value></data>
+  <data name="Subtitle_MBoosterPedals" xml:space="preserve"><value>// vom Host gerenderte Effekte · Rolle + Position pro Gerät</value></data>
+  <data name="SliderLabel_Device" xml:space="preserve"><value>Gerät</value></data>
+  <data name="Status_NoMBooster" xml:space="preserve"><value>Kein mBooster verbunden</value></data>
+  <data name="Section_PedalRole" xml:space="preserve"><value>PEDALROLLE</value></data>
+  <data name="SliderLabel_Role" xml:space="preserve"><value>Rolle</value></data>
+  <data name="Option_Disabled" xml:space="preserve"><value>Deaktiviert</value></data>
+  <data name="Option_Throttle" xml:space="preserve"><value>Gas</value></data>
+  <data name="Option_Brake" xml:space="preserve"><value>Bremse</value></data>
+  <data name="Option_Clutch" xml:space="preserve"><value>Kupplung</value></data>
+  <data name="Section_Effects" xml:space="preserve"><value>EFFEKTE</value></data>
+  <data name="Subtitle_EffectsTriggers" xml:space="preserve"><value>// Auslöser: ABS bei Spielsignal · Lockup bei Bremse &gt; 0,8 · Threshold an der Flanke · Engine durchgehend</value></data>
+  <data name="Section_Abs" xml:space="preserve"><value>ABS</value></data>
+  <data name="Label_Enable" xml:space="preserve"><value>Aktivieren</value></data>
+  <data name="Button_Test1s" xml:space="preserve"><value>1 s testen</value></data>
+  <data name="Section_Lockup" xml:space="preserve"><value>Lockup</value></data>
+  <data name="Section_Threshold" xml:space="preserve"><value>Schwellwert</value></data>
+  <data name="Section_EngineContinuous" xml:space="preserve"><value>Motor (durchgehend — automatisch auf 10 % begrenzt)</value></data>
+  <data name="Subtitle_CalibrationExperimental" xml:space="preserve"><value>// experimentell — wird ggf. nicht von der mBooster-Firmware übernommen</value></data>
+  <data name="Label_ReversedDirection" xml:space="preserve"><value>Richtung umgekehrt</value></data>
+  <data name="SliderLabel_MinRaw" xml:space="preserve"><value>Min (roh)</value></data>
+  <data name="SliderLabel_MaxRaw" xml:space="preserve"><value>Max (roh)</value></data>
+  <data name="Button_ReadFromDevice" xml:space="preserve"><value>VOM GERÄT LESEN</value></data>
+  <data name="Button_Apply" xml:space="preserve"><value>ÜBERNEHMEN</value></data>
+  <data name="Section_UniversalHubPedals" xml:space="preserve"><value>UNIVERSAL-HUB · PEDALE</value></data>
+  <data name="Subtitle_PedalsPort" xml:space="preserve"><value>// Pedal-Port (alle 2 Sekunden abgefragt)</value></data>
+  <data name="Label_PedalsPort" xml:space="preserve"><value>Pedal-Port</value></data>
+  <data name="Section_Accessories" xml:space="preserve"><value>ZUBEHÖR</value></data>
+  <data name="Label_Port1" xml:space="preserve"><value>Port 1</value></data>
+  <data name="Label_Port2" xml:space="preserve"><value>Port 2</value></data>
+  <data name="Label_Port3" xml:space="preserve"><value>Port 3</value></data>
+  <data name="Section_Profiles" xml:space="preserve"><value>PROFILE</value></data>
+  <data name="SliderLabel_ApplyProfileOnLaunch" xml:space="preserve"><value>Profil-Einstellungen beim Start anwenden</value></data>
+  <data name="Section_WheelLedOutput" xml:space="preserve"><value>LENKRAD-LED-AUSGABE</value></data>
+  <data name="Subtitle_WheelLedOutput" xml:space="preserve"><value>// Drosselung von RPM + Tasten</value></data>
+  <data name="Hint_LedOptionsRecommendedOff" xml:space="preserve"><value>Empfehlung: die LED-Optionen unten auf AUS lassen, außer es treten LED-Probleme auf.</value></data>
+  <data name="SliderLabel_LimitWheelUpdates" xml:space="preserve"><value>Updates ans Lenkrad begrenzen</value></data>
+  <data name="Hint_OnlySendLedWhenChanged" xml:space="preserve"><value>LED-Daten nur senden, wenn sie sich tatsächlich ändern.</value></data>
+  <data name="SliderLabel_AlwaysResendBitmask" xml:space="preserve"><value>Bitmaske immer erneut senden</value></data>
+  <data name="Hint_AlwaysResendBitmask" xml:space="preserve"><value>Sendet die LED-Bitmaske bei jedem Farb-Update mit, auch wenn sie unverändert ist. Verursacht zusätzlichen Datenverkehr.</value></data>
+  <data name="Section_UsbDetection" xml:space="preserve"><value>USB-ERKENNUNG</value></data>
+  <data name="SliderLabel_DisableSerialProbe" xml:space="preserve"><value>Serielles Probe-Fallback deaktivieren (erweitert)</value></data>
+  <data name="Hint_DisableSerialProbe" xml:space="preserve"><value>Nur erforderlich, wenn das Plugin mit einem falschen Gerät kommuniziert.</value></data>
+  <data name="SliderLabel_DisableAb9Detection" xml:space="preserve"><value>Erkennung des AB9-Aktivschalthebels deaktivieren</value></data>
+  <data name="Hint_DisableAb9Detection" xml:space="preserve"><value>Überspringt das AB9-Reconnect-Probe.</value></data>
+  <data name="Section_DashboardTelemetry" xml:space="preserve"><value>DASHBOARD-TELEMETRIE</value></data>
+  <data name="Label_UploadDashboardOnConnect" xml:space="preserve"><value>Dashboard beim Verbinden hochladen</value></data>
+  <data name="Label_DownloadDashboardsFromWheel" xml:space="preserve"><value>Dashboards vom Lenkrad herunterladen</value></data>
+  <data name="Label_WheelFirmwareEra" xml:space="preserve"><value>Lenkrad-Firmware-Ära:</value></data>
+  <data name="Option_FirmwareEraAuto" xml:space="preserve"><value>Auto — Versuch zur Erkennung anhand des Lenkrad-Handshakes</value></data>
+  <data name="Option_FirmwareEra2024" xml:space="preserve"><value>Ära 2024 — (URL-Abonnement)</value></data>
+  <data name="Option_FirmwareEra2025" xml:space="preserve"><value>Ära 2025 — VGS</value></data>
+  <data name="Option_FirmwareEra2026" xml:space="preserve"><value>Ära 2026 — CSP/KSP</value></data>
+  <data name="Hint_FirmwareEra" xml:space="preserve"><value>Auto ermittelt die Firmware-Ära aus dem Handshake des Lenkrads und wählt das passende Protokoll. Nur überschreiben, falls die Telemetrie nicht funktioniert.</value></data>
+  <data name="Section_Reset" xml:space="preserve"><value>ZURÜCKSETZEN</value></data>
+  <data name="Button_ClearAllSettings" xml:space="preserve"><value>ALLE EINSTELLUNGEN & PROFILE LÖSCHEN</value></data>
+  <data name="Hint_ClearAllSettingsWarning" xml:space="preserve"><value>Damit werden alle Plugin-Einstellungen und Profile auf ihre Standardwerte zurückgesetzt.</value></data>
+  <data name="Banner_NotWorkingYet" xml:space="preserve"><value>⚠  Funktioniert noch nicht</value></data>
+  <data name="Hint_DashboardUploadNotWorking" xml:space="preserve"><value>Der Dashboard-Upload ist in Entwicklung und überträgt aktuell KEINE Dateien an das Lenkrad.</value></data>
+  <data name="Section_DashboardUpload" xml:space="preserve"><value>DASHBOARD-UPLOAD</value></data>
+  <data name="Subtitle_DashboardUpload" xml:space="preserve"><value>// eine .mzdash-Datei an das verbundene Lenkrad senden</value></data>
+  <data name="Hint_UploadStatusFormat" xml:space="preserve"><value>Der Status spiegelt das zuletzt vom Lenkrad bestätigte ACK wider.</value></data>
+  <data name="Label_Source" xml:space="preserve"><value>QUELLE</value></data>
+  <data name="Option_LocalMzdashFile" xml:space="preserve"><value>Lokale .mzdash-Datei</value></data>
+  <data name="Option_DashboardLibrary" xml:space="preserve"><value>Dashboard-Bibliothek</value></data>
+  <data name="Button_PickMzdash" xml:space="preserve"><value>.MZDASH WÄHLEN…</value></data>
+  <data name="Status_NoFileSelected" xml:space="preserve"><value>(keine Datei ausgewählt)</value></data>
+  <data name="Label_Dashboard" xml:space="preserve"><value>Dashboard:</value></data>
+  <data name="Button_UploadNow" xml:space="preserve"><value>JETZT HOCHLADEN</value></data>
+  <data name="Status_Idle" xml:space="preserve"><value>im Leerlauf</value></data>
+  <data name="Label_DashboardName" xml:space="preserve"><value>Dashboard-Name:</value></data>
+  <data name="Label_RawSize" xml:space="preserve"><value>Rohgröße:</value></data>
+  <data name="Label_Md5" xml:space="preserve"><value>MD5:</value></data>
+  <data name="Label_InFlight" xml:space="preserve"><value>In Übertragung:</value></data>
+  <data name="Label_LastAckBytes" xml:space="preserve"><value>Letztes ACK bytes_written / total:</value></data>
+  <data name="Label_LastAckStatus" xml:space="preserve"><value>Letztes ACK-Statusbyte:</value></data>
+  <data name="Hint_UploadRequiresConnection" xml:space="preserve"><value>Hinweis: Uploads erfordern eine bestehende Verbindung zum Lenkrad und eine ausgehandelte Management-Sitzung.</value></data>
+  <data name="Section_WheelFiles" xml:space="preserve"><value>LENKRAD-DATEIEN</value></data>
+  <data name="Subtitle_WheelFiles" xml:space="preserve"><value>// auf dem Lenkrad geladene Dashboards</value></data>
+  <data name="Hint_DeleteDisabled" xml:space="preserve"><value>Löschen ist vorübergehend deaktiviert.</value></data>
+  <data name="DataGridHeader_State" xml:space="preserve"><value>Status</value></data>
+  <data name="DataGridHeader_Title" xml:space="preserve"><value>Titel</value></data>
+  <data name="DataGridHeader_DirName" xml:space="preserve"><value>Verzeichnis</value></data>
+  <data name="DataGridHeader_Hash" xml:space="preserve"><value>Hash</value></data>
+  <data name="DataGridHeader_LastModified" xml:space="preserve"><value>Zuletzt geändert</value></data>
+  <data name="Button_Delete" xml:space="preserve"><value>LÖSCHEN</value></data>
+  <data name="Tooltip_DeleteDisabled" xml:space="preserve"><value>Vorübergehend deaktiviert.</value></data>
+  <data name="Section_CoapServer" xml:space="preserve"><value>COAP-SERVER</value></data>
+  <data name="Subtitle_CoapServer" xml:space="preserve"><value>// eingebetteter CoAP-Server auf Loopback</value></data>
+  <data name="Hint_CoapServerEnabled" xml:space="preserve"><value>Wenn aktiviert, betreibt das Plugin einen eingebetteten CoAP-SDK-Steuerserver.</value></data>
+  <data name="SliderLabel_EnableCoapServer" xml:space="preserve"><value>CoAP-SDK-Server aktivieren</value></data>
+  <data name="Section_UdpControl" xml:space="preserve"><value>UDP-STEUERUNG</value></data>
+  <data name="Subtitle_UdpControl" xml:space="preserve"><value>// einfache CBOR-über-UDP-Steueroberfläche</value></data>
+  <data name="Hint_UdpControlEnabled" xml:space="preserve"><value>Wenn aktiviert, betreibt das Plugin einen eingebetteten UDP-Steuerserver für Drittanbieter-Tools zur Lenkrad-Konfiguration.</value></data>
+  <data name="SliderLabel_EnableUdpControl" xml:space="preserve"><value>UDP-Steuerserver aktivieren</value></data>
+  <data name="Label_PortNumber" xml:space="preserve"><value>Port</value></data>
+  <data name="Section_Status" xml:space="preserve"><value>STATUS</value></data>
+  <data name="Label_CoapServer" xml:space="preserve"><value>CoAP-Server</value></data>
+  <data name="Label_UdpControlServer" xml:space="preserve"><value>UDP-Steuerung</value></data>
+  <data name="Section_RecentRequests" xml:space="preserve"><value>LETZTE ANFRAGEN</value></data>
+  <data name="Subtitle_RecentRequests" xml:space="preserve"><value>// letzte 20 Anfragen pro Server · live</value></data>
+  <data name="Section_About" xml:space="preserve"><value>ÜBER</value></data>
+  <data name="Subtitle_About" xml:space="preserve"><value>// Open-Source-SimHub-Plugin</value></data>
+  <data name="Label_UnofficialMozaPlugin" xml:space="preserve"><value>Inoffizielles MOZA-SimHub-Plugin</value></data>
+  <data name="Label_VersionPlaceholder" xml:space="preserve"><value>Version —</value></data>
+  <data name="Hint_AboutDescription" xml:space="preserve"><value>Ein inoffizielles SimHub-Plugin, das direkt über die serielle Schnittstelle mit MOZA-Racing-Hardware kommuniziert — Hardware-Konfiguration, LED-Effekt-Pipeline und Dashboard-Streaming. Nicht mit MOZA / Gudsen Technology verbunden.</value></data>
+  <data name="Hint_SponsorshipsAppreciated" xml:space="preserve"><value>Sponsorings sind sehr willkommen — Unterstützung für Hardware hinzuzufügen, die ich nicht besitze, kann schwierig sein!</value></data>
+  <data name="Hint_ThanksToTesters" xml:space="preserve"><value>Riesigen Dank an alle frühen Alpha- und Beta-Tester, die ihre Zeit — und ihre Nerven — investiert haben, während ich herausgefunden habe, wie das MOZA-Protokoll funktioniert. Ohne euch gäbe es dieses Plugin nicht.</value></data>
+  <data name="Button_Github" xml:space="preserve"><value>GitHub</value></data>
+  <data name="Button_JoinDiscord" xml:space="preserve"><value>Discord beitreten</value></data>
+  <data name="Button_SponsorDevelopment" xml:space="preserve"><value>Entwicklung sponsern</value></data>
+  <data name="Tooltip_Github" xml:space="preserve"><value>github.com/giantorth/moza-simhub-plugin</value></data>
+  <data name="Tooltip_JoinDiscord" xml:space="preserve"><value>Dem Discord des Projekts beitreten</value></data>
+  <data name="Tooltip_Sponsor" xml:space="preserve"><value>github.com/sponsors/giantorth</value></data>
+  <data name="Label_UpdateAvailable" xml:space="preserve"><value>Update verfügbar</value></data>
+  <data name="Button_OpenReleaseNotes" xml:space="preserve"><value>Release-Notes öffnen</value></data>
+  <data name="Button_SkipThisVersion" xml:space="preserve"><value>Diese Version überspringen</value></data>
+  <data name="Button_DismissUpdate" xml:space="preserve"><value>Verwerfen</value></data>
+  <data name="Label_CheckForUpdates" xml:space="preserve"><value>Automatisch nach Updates suchen</value></data>
+  <data name="Label_ReleaseChannel" xml:space="preserve"><value>Release-Kanal</value></data>
+  <data name="Option_ReleaseChannelStable" xml:space="preserve"><value>Stabil</value></data>
+  <data name="Option_ReleaseChannelDev" xml:space="preserve"><value>Entwicklung</value></data>
+  <data name="Button_CheckNow" xml:space="preserve"><value>Jetzt prüfen</value></data>
+  <data name="Status_UpdateNeverChecked" xml:space="preserve"><value>Noch nie geprüft</value></data>
+  <data name="Status_UpdateChecking" xml:space="preserve"><value>Wird geprüft…</value></data>
+  <data name="Status_UpdateUpToDate" xml:space="preserve"><value>Auf dem neuesten Stand</value></data>
+  <data name="Status_UpdateFailedNetwork" xml:space="preserve"><value>Prüfung fehlgeschlagen (Netzwerk)</value></data>
+  <data name="Status_UpdateFailedHttp" xml:space="preserve"><value>Prüfung fehlgeschlagen (Server)</value></data>
+  <data name="Status_UpdateFailedParse" xml:space="preserve"><value>Prüfung fehlgeschlagen (Antwortformat)</value></data>
+  <data name="Button_InstallUpdate" xml:space="preserve"><value>Update installieren</value></data>
+  <data name="Status_DownloadingStart" xml:space="preserve"><value>Download wird gestartet…</value></data>
+  <data name="Status_Downloading" xml:space="preserve"><value>Lade herunter {0} % ({1} von {2})</value></data>
+  <data name="Status_DownloadingIndeterminate" xml:space="preserve"><value>Lade herunter… ({0})</value></data>
+  <data name="Status_Extracting" xml:space="preserve"><value>Wird entpackt…</value></data>
+  <data name="Status_Installing" xml:space="preserve"><value>Wird installiert…</value></data>
+  <data name="Status_InstalledRestartRequired" xml:space="preserve"><value>Update installiert — SimHub neu starten, um v{0} zu laden</value></data>
+  <data name="Status_InstallFailed" xml:space="preserve"><value>Installation fehlgeschlagen: {0}</value></data>
+  <data name="Status_InstallFailedBadPackage" xml:space="preserve"><value>Release-Paket ist ungültig</value></data>
+  <data name="Status_InstallFailedPendingRestart" xml:space="preserve"><value>vorherige Installation steht aus — SimHub zuerst neu starten</value></data>
+  <data name="Status_InstallFailedWriteDenied" xml:space="preserve"><value>kein Schreibzugriff auf den Plugin-Ordner</value></data>
+  <data name="Section_Updates" xml:space="preserve"><value>UPDATES</value></data>
+  <data name="Subtitle_Updates" xml:space="preserve"><value>// Update-Benachrichtigung im Plugin</value></data>
+  <data name="Section_Bandwidth" xml:space="preserve"><value>BANDBREITE</value></data>
+  <data name="Subtitle_Bandwidth" xml:space="preserve"><value>// Serielle Datenrate · 30-Sekunden-Fenster</value></data>
+  <data name="Label_Inbound" xml:space="preserve"><value>EINGEHEND</value></data>
+  <data name="Label_Outbound" xml:space="preserve"><value>AUSGEHEND</value></data>
+  <data name="Label_Capacity" xml:space="preserve"><value>KAPAZITÄT</value></data>
+  <data name="Label_Peak" xml:space="preserve"><value>SPITZE</value></data>
+  <data name="Label_Session" xml:space="preserve"><value>SITZUNG</value></data>
+  <data name="Section_SerialTrafficCapture" xml:space="preserve"><value>SERIELLE DATEN AUFZEICHNEN</value></data>
+  <data name="Subtitle_SerialTrafficCapture" xml:space="preserve"><value>// zeichnet jeden TX/RX-Frame auf</value></data>
+  <data name="Hint_CaptureDataInMemory" xml:space="preserve"><value>Die Daten liegen nur im Arbeitsspeicher — zwischen Programmstarts wird nichts gespeichert. „Stopp“ drücken, um ein Diagnose-Bundle als ZIP zu exportieren.</value></data>
+  <data name="Button_StartCapture" xml:space="preserve"><value>AUFZEICHNUNG STARTEN</value></data>
+  <data name="Label_AlwaysCaptureOnStartup" xml:space="preserve"><value>Diagnose-Aufzeichnung beim Start / Spielwechsel immer beginnen</value></data>
+  <data name="Tooltip_AlwaysCaptureOnStartup" xml:space="preserve"><value>Wenn aktiv, beginnt die serielle Aufzeichnung automatisch bei jedem Plugin-Start.</value></data>
+  <data name="Button_ExportBundle" xml:space="preserve"><value>BUNDLE EXPORTIEREN (ZIP)…</value></data>
+  <data name="Button_CopyCapture" xml:space="preserve"><value>AUFZEICHNUNG IN ZWISCHENABLAGE KOPIEREN</value></data>
+  <data name="Section_FullDiagReport" xml:space="preserve"><value>VOLLSTÄNDIGER DIAGNOSE-BERICHT</value></data>
+  <data name="Subtitle_FullDiagReport" xml:space="preserve"><value>// Debug-Informationen</value></data>
+  <data name="Button_Expand" xml:space="preserve"><value>AUSKLAPPEN</value></data>
+  <data name="Button_CopyAll" xml:space="preserve"><value>ALLES IN ZWISCHENABLAGE KOPIEREN</value></data>
+  <data name="Hint_ClickExpandToRender" xml:space="preserve"><value>„Ausklappen“ drücken, um den vollständigen mehrteiligen Bericht zu erzeugen.</value></data>
+  <data name="Hint_MBoosterIntro" xml:space="preserve"><value>Jeder verbundene mBooster erscheint unten. Wähle eine Rolle (Gas/Bremse/Kupplung) pro Gerät, um seine Pedalposition zu zuweisen. Der Kalibrierungs-Abschnitt ist experimentell.</value></data>
+  <data name="Hint_MBoosterCalibrationWarning" xml:space="preserve"><value>Noch nicht getestet.</value></data>
+  <data name="Title_PickLedColor" xml:space="preserve"><value>LED-Farbe wählen</value></data>
+  <data name="Label_Palette" xml:space="preserve"><value>PALETTE</value></data>
+  <data name="Label_Last" xml:space="preserve"><value>ZULETZT</value></data>
+  <data name="Label_FineTuneRgb" xml:space="preserve"><value>FEINABSTIMMUNG · RGB</value></data>
+  <data name="Button_Cancel" xml:space="preserve"><value>ABBRECHEN</value></data>
+  <data name="Button_Ok" xml:space="preserve"><value>OK</value></data>
+  <data name="Section_BaseAmbientLeds" xml:space="preserve"><value>MOZA WHEEL BASE · AMBIENTE LEDS</value></data>
+  <data name="Label_BaseModel" xml:space="preserve"><value>Base-Modell</value></data>
+  <data name="Hint_NoBaseAmbientDetected" xml:space="preserve"><value>Keine Ambiente-LEDs an der Base erkannt. R9/R12-Bases haben keinen LED-Streifen; dieses Panel ist nur bei R21/R25/R27-Bases aktiv.</value></data>
+  <data name="Section_Mode" xml:space="preserve"><value>MODUS</value></data>
+  <data name="SliderLabel_IndicatorState" xml:space="preserve"><value>Indikator-Status</value></data>
+  <data name="Option_Off" xml:space="preserve"><value>Aus</value></data>
+  <data name="Option_On" xml:space="preserve"><value>An</value></data>
+  <data name="SliderLabel_StandbyAnimation" xml:space="preserve"><value>Standby-Animation</value></data>
+  <data name="Option_Constant" xml:space="preserve"><value>Konstant</value></data>
+  <data name="Option_Breath" xml:space="preserve"><value>Atmend</value></data>
+  <data name="Option_Cycle" xml:space="preserve"><value>Zyklus</value></data>
+  <data name="Option_Rainbow" xml:space="preserve"><value>Regenbogen</value></data>
+  <data name="Option_Flow" xml:space="preserve"><value>Fluss</value></data>
+  <data name="Section_Brightness" xml:space="preserve"><value>HELLIGKEIT</value></data>
+  <data name="SliderLabel_Brightness" xml:space="preserve"><value>Helligkeit</value></data>
+  <data name="Section_Sleep" xml:space="preserve"><value>RUHEZUSTAND</value></data>
+  <data name="SliderLabel_SleepMode" xml:space="preserve"><value>Ruhezustands-Modus</value></data>
+  <data name="Option_Enabled" xml:space="preserve"><value>Aktiviert</value></data>
+  <data name="SliderLabel_SleepTimeout" xml:space="preserve"><value>Ruhezustands-Zeit</value></data>
+  <data name="Section_PowerOnOffColor" xml:space="preserve"><value>EINSCHALT- / AUSSCHALT-FARBE</value></data>
+  <data name="SliderLabel_StartupColor" xml:space="preserve"><value>Startfarbe</value></data>
+  <data name="SliderLabel_ShutdownColor" xml:space="preserve"><value>Abschaltfarbe</value></data>
+  <data name="Section_MozaDashboard" xml:space="preserve"><value>MOZA-DASHBOARD</value></data>
+  <data name="Status_SearchingForDashboard" xml:space="preserve"><value>Suche nach Dashboard…</value></data>
+  <data name="Section_IndicatorModes" xml:space="preserve"><value>INDIKATORMODI</value></data>
+  <data name="SliderLabel_RpmIndicatorMode" xml:space="preserve"><value>RPM-Indikatormodus</value></data>
+  <data name="Option_SimHubMode" xml:space="preserve"><value>SimHub-Modus</value></data>
+  <data name="Option_AlwaysOn" xml:space="preserve"><value>Immer an</value></data>
+  <data name="SliderLabel_RpmDisplayMode" xml:space="preserve"><value>RPM-Anzeigemodus</value></data>
+  <data name="Option_Mode1" xml:space="preserve"><value>Modus 1</value></data>
+  <data name="Option_Mode2" xml:space="preserve"><value>Modus 2</value></data>
+  <data name="SliderLabel_FlagsIndicatorMode" xml:space="preserve"><value>Flaggen-Indikatormodus</value></data>
+  <data name="SliderLabel_RpmBrightness" xml:space="preserve"><value>RPM-Helligkeit</value></data>
+  <data name="SliderLabel_FlagsBrightness" xml:space="preserve"><value>Flaggen-Helligkeit</value></data>
+  <data name="Section_RpmLedColors" xml:space="preserve"><value>RPM-LED-FARBEN</value></data>
+  <data name="Section_RpmBlinkColors" xml:space="preserve"><value>RPM-BLINKFARBEN</value></data>
+  <data name="Subtitle_RpmBlinkColors" xml:space="preserve"><value>// werden angezeigt, wenn die RPM in den roten Bereich gehen</value></data>
+  <data name="Section_FlagLedColors" xml:space="preserve"><value>FLAGGEN-LED-FARBEN</value></data>
+  <data name="Label_SteeringAngle" xml:space="preserve"><value>LENKWINKEL</value></data>
+  <data name="Toggle_Off" xml:space="preserve"><value>AUS</value></data>
+  <data name="Toggle_On" xml:space="preserve"><value>AN</value></data>
+  <data name="TabHeader_Inputs" xml:space="preserve"><value>Eingaben</value></data>
+  <data name="TabHeader_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
+  <data name="TabHeader_Rpm" xml:space="preserve"><value>RPM</value></data>
+  <data name="TabHeader_Buttons" xml:space="preserve"><value>Tasten</value></data>
+  <data name="TabHeader_Knobs" xml:space="preserve"><value>Drehregler</value></data>
+  <data name="TabHeader_Files" xml:space="preserve"><value>Dateien</value></data>
+  <data name="TabHeader_Sleep" xml:space="preserve"><value>Ruhezustand</value></data>
+  <data name="Status_SearchingForWheel" xml:space="preserve"><value>Suche nach Lenkrad…</value></data>
+  <data name="Section_LivePaddles" xml:space="preserve"><value>LIVE-PADDLES</value></data>
+  <data name="Label_PaddleLeft" xml:space="preserve"><value>LINKS</value></data>
+  <data name="Label_PaddleRight" xml:space="preserve"><value>RECHTS</value></data>
+  <data name="Label_PaddleCombined" xml:space="preserve"><value>KOMBINIERT</value></data>
+  <data name="Section_ActiveButtons" xml:space="preserve"><value>AKTIVE TASTEN</value></data>
+  <data name="Section_Joystick" xml:space="preserve"><value>JOYSTICK</value></data>
+  <data name="Subtitle_JoystickAssignment" xml:space="preserve"><value>// Richtungs-Stick-Zuweisung</value></data>
+  <data name="Hint_NoJoystickConfig" xml:space="preserve"><value>Das Lenkrad hat noch keine Joystick-Konfiguration gemeldet. Lenkrad anschließen und auf den Abschluss der Identity-Probe warten.</value></data>
+  <data name="Label_EnableDashboardTelemetry" xml:space="preserve"><value>Dashboard-Telemetrie aktivieren</value></data>
+  <data name="Button_LoadMzdash" xml:space="preserve"><value>.MZDASH LADEN…</value></data>
+  <data name="Button_SetFolder" xml:space="preserve"><value>ORDNER WÄHLEN…</value></data>
+  <data name="Button_AutoDetect" xml:space="preserve"><value>AUTO-ERKENNUNG</value></data>
+  <data name="Tooltip_LoadMzdash" xml:space="preserve"><value>Lokale .mzdash-Datei für Tier-Def-Kanalabgleich laden</value></data>
+  <data name="Tooltip_SetFolder" xml:space="preserve"><value>Einen Ordner mit .mzdash-Dateien als Dashboard-Bibliothek festlegen</value></data>
+  <data name="Tooltip_AutoDetect" xml:space="preserve"><value>Den Dashboard-Ordner für das verbundene Lenkrad automatisch erkennen</value></data>
+  <data name="Button_SendTestPattern" xml:space="preserve"><value>▶ TESTMUSTER SENDEN</value></data>
+  <data name="Button_StopTest" xml:space="preserve"><value>■ STOPP</value></data>
+  <data name="Section_ChannelMappings" xml:space="preserve"><value>KANAL-ZUORDNUNGEN</value></data>
+  <data name="Hint_ClickPencilForProperty" xml:space="preserve"><value>Klicke auf den Stift in einer Zeile, um eine SimHub-Eigenschaft zu wählen</value></data>
+  <data name="Status_LoadingChannelMappings" xml:space="preserve"><value>Lade Kanal-Zuordnungen…</value></data>
+  <data name="DataGridHeader_Channel" xml:space="preserve"><value>Kanal</value></data>
+  <data name="DataGridHeader_SimHubProperty" xml:space="preserve"><value>SimHub-Eigenschaft</value></data>
+  <data name="DataGridHeader_CurrentValue" xml:space="preserve"><value>Aktueller Wert</value></data>
+  <data name="Tooltip_EditMapping" xml:space="preserve"><value>SimHub-Eigenschaftsbindung bearbeiten</value></data>
+  <data name="Button_ResetToDefaults" xml:space="preserve"><value>AUF STANDARDS ZURÜCKSETZEN</value></data>
+  <data name="Section_Display" xml:space="preserve"><value>ANZEIGE</value></data>
+  <data name="SliderLabel_DisplayBrightness" xml:space="preserve"><value>Display-Helligkeit</value></data>
+  <data name="SliderLabel_StandbyTime" xml:space="preserve"><value>Standby-Zeit</value></data>
+  <data name="Option_Time1Min" xml:space="preserve"><value>1 Minute</value></data>
+  <data name="Option_Time2Min" xml:space="preserve"><value>2 Minuten</value></data>
+  <data name="Option_Time3Min" xml:space="preserve"><value>3 Minuten</value></data>
+  <data name="Option_Time4Min" xml:space="preserve"><value>4 Minuten</value></data>
+  <data name="Option_Time5Min" xml:space="preserve"><value>5 Minuten</value></data>
+  <data name="Option_Time10Min" xml:space="preserve"><value>10 Minuten</value></data>
+  <data name="Option_Time15Min" xml:space="preserve"><value>15 Minuten</value></data>
+  <data name="Option_Time20Min" xml:space="preserve"><value>20 Minuten</value></data>
+  <data name="Option_Time25Min" xml:space="preserve"><value>25 Minuten</value></data>
+  <data name="Option_Time30Min" xml:space="preserve"><value>30 Minuten</value></data>
+  <data name="Option_Time35Min" xml:space="preserve"><value>35 Minuten</value></data>
+  <data name="Option_Time40Min" xml:space="preserve"><value>40 Minuten</value></data>
+  <data name="Option_Time45Min" xml:space="preserve"><value>45 Minuten</value></data>
+  <data name="Option_Time1Hour" xml:space="preserve"><value>1 Stunde</value></data>
+  <data name="Option_Time2Hour" xml:space="preserve"><value>2 Stunden</value></data>
+  <data name="Option_Time3Hour" xml:space="preserve"><value>3 Stunden</value></data>
+  <data name="Option_Time4Hour" xml:space="preserve"><value>4 Stunden</value></data>
+  <data name="Option_Time5Hour" xml:space="preserve"><value>5 Stunden</value></data>
+  <data name="Section_RpmLedMode" xml:space="preserve"><value>RPM-LED-MODUS</value></data>
+  <data name="SliderLabel_RpmLedMode" xml:space="preserve"><value>RPM-LED-Modus</value></data>
+  <data name="Option_Static" xml:space="preserve"><value>Statisch</value></data>
+  <data name="SliderLabel_RpmIdleEffect" xml:space="preserve"><value>RPM-Leerlauf-Effekt</value></data>
+  <data name="Option_Breathing" xml:space="preserve"><value>Atmend</value></data>
+  <data name="Option_ColorCycle" xml:space="preserve"><value>Farbzyklus</value></data>
+  <data name="Option_SandFlow" xml:space="preserve"><value>Sandfluss</value></data>
+  <data name="Option_RgbPulse" xml:space="preserve"><value>RGB-Puls</value></data>
+  <data name="SliderLabel_RpmIdleSpeed" xml:space="preserve"><value>RPM-Leerlauf-Geschwindigkeit</value></data>
+  <data name="Section_RpmLedColorsStatic" xml:space="preserve"><value>RPM-LED-FARBEN (STATISCH)</value></data>
+  <data name="Subtitle_RpmLedColorsStatic" xml:space="preserve"><value>// werden angezeigt, wenn keine Telemetrie gesendet wird · LED anklicken zum Umfärben</value></data>
+  <data name="Label_LedPlaceholder" xml:space="preserve"><value>LED 01</value></data>
+  <data name="Subtitle_ClickFlagToRecolor" xml:space="preserve"><value>// Flagge anklicken zum Umfärben</value></data>
+  <data name="Label_FlagPlaceholder" xml:space="preserve"><value>FLAGGE 1</value></data>
+  <data name="Section_EsWheelRpmIndicator" xml:space="preserve"><value>ES-LENKRAD · RPM-INDIKATOR</value></data>
+  <data name="Subtitle_EsLegacy" xml:space="preserve"><value>// Legacy-ES-Protokoll</value></data>
+  <data name="SliderLabel_IndicatorMode" xml:space="preserve"><value>Indikatormodus</value></data>
+  <data name="SliderLabel_DisplayMode" xml:space="preserve"><value>Anzeigemodus</value></data>
+  <data name="Section_ButtonLedMode" xml:space="preserve"><value>TASTEN-LED-MODUS</value></data>
+  <data name="SliderLabel_ButtonLedMode" xml:space="preserve"><value>Tasten-LED-Modus</value></data>
+  <data name="SliderLabel_ButtonIdleEffect" xml:space="preserve"><value>Tasten-Leerlauf-Effekt</value></data>
+  <data name="SliderLabel_ButtonIdleSpeed" xml:space="preserve"><value>Tasten-Leerlauf-Geschwindigkeit</value></data>
+  <data name="Section_ButtonLedColors" xml:space="preserve"><value>TASTEN-LED-FARBEN</value></data>
+  <data name="Subtitle_ButtonLedColors" xml:space="preserve"><value>// Taste anklicken zum Umfärben · „Standard während Telemetrie“ ersetzt nicht aktive Tasten durch die gewählte Farbe</value></data>
+  <data name="Label_ButtonPlaceholder" xml:space="preserve"><value>TASTE 01</value></data>
+  <data name="Section_KnobLedMode" xml:space="preserve"><value>DREHREGLER-LED-MODUS</value></data>
+  <data name="SliderLabel_KnobLedMode" xml:space="preserve"><value>Drehregler-LED-Modus</value></data>
+  <data name="SliderLabel_KnobIdleEffect" xml:space="preserve"><value>Drehregler-Leerlauf-Effekt</value></data>
+  <data name="SliderLabel_KnobIdleSpeed" xml:space="preserve"><value>Drehregler-Leerlauf-Geschwindigkeit</value></data>
+  <data name="Section_KnobSettings" xml:space="preserve"><value>DREHREGLER-EINSTELLUNGEN</value></data>
+  <data name="Label_SignalMode" xml:space="preserve"><value>SIGNALMODUS</value></data>
+  <data name="Subtitle_SignalMode" xml:space="preserve"><value>// wie jeder Drehgeber Eingaben meldet</value></data>
+  <data name="SliderLabel_AllRotaries" xml:space="preserve"><value>Alle Drehgeber</value></data>
+  <data name="Label_Colours" xml:space="preserve"><value>FARBEN</value></data>
+  <data name="Subtitle_KnobColours" xml:space="preserve"><value>// klicke auf eine beliebige Ring-LED oder das zentrale Farbfeld, um die aktive Farbe dieses Drehreglers zu setzen</value></data>
+  <data name="Label_KnobEditing" xml:space="preserve"><value>BEARBEITEN · DREHREGLER 1 · AKTIV</value></data>
+  <data name="Button_FillRingWithSelected" xml:space="preserve"><value>RING MIT AUSWAHL FÜLLEN</value></data>
+  <data name="Button_CopyKnobToAll" xml:space="preserve"><value>DIESEN DREHREGLER AUF ALLE KOPIEREN</value></data>
+  <data name="Banner_DashboardUploadNotWorkingYet" xml:space="preserve"><value>⚠  Dashboard-Upload funktioniert noch nicht</value></data>
+  <data name="Section_SleepLight" xml:space="preserve"><value>RUHELICHT</value></data>
+  <data name="Subtitle_SleepLight" xml:space="preserve"><value>// was das Lenkrad nach Ablauf der Leerlaufzeit anzeigt</value></data>
+  <data name="SliderLabel_Speed" xml:space="preserve"><value>Geschwindigkeit</value></data>
+  <data name="SliderLabel_Color" xml:space="preserve"><value>Farbe</value></data>
+  <data name="Section_Language" xml:space="preserve"><value>SPRACHE</value></data>
+  <data name="SliderLabel_Language" xml:space="preserve"><value>Sprache</value></data>
+  <data name="Hint_LanguageChangeRestart" xml:space="preserve"><value>Diese Einstellungsseite schließen und erneut öffnen, um die neue Sprache zu übernehmen. „Auto“ folgt der Sprache von SimHub, danach der des Betriebssystems.</value></data>
+</root>


### PR DESCRIPTION
Adds a full German translation of every plugin UI string. Wires the new resource into the language picker, the strongly-typed accessor, and the csproj's embedded resource list so it ships inside the main MozaPlugin.dll alongside the existing locales. Both 'auto' (SimHub / OS locale chain) and an explicit 'de' pick from the in-plugin selector resolve correctly; de-AT/de-CH fall through the parent chain to de.